### PR TITLE
Traductions Brunch et Hapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are willing to contribute, open a pull request to complete, update or fil
 * [Bower](/glossary/BOWER.md): a package manager for front-end dependencies.
 * [Broccoli](/glossary/BROCCOLI.md): a fast and reliable asset pipeline.
 * [Browserify](/glossary/BROWSERIFY.md): a tool making possible to use the `require` function from Node.js within the browser.
-* [Brunch](/glossary/BRUNCH.md): a tool focusing on the production of deployment-ready files from development files.
+* [Brunch](/glossary/BRUNCH.md): Un outil ciblé sur la production de fichiers prêts à être déployés à partir de fichiers de développement.
 
 ### C
 
@@ -85,7 +85,7 @@ If you are willing to contribute, open a pull request to complete, update or fil
 
 ### H
 
-* [Hapi](/glossary/HAPI.md): a Node JS framework for writing services and more.
+* [Hapi](/glossary/HAPI.md): Un framework Node JS pour écrire des services et plus.
 * [Hoisting](/glossary/HOISTING.md): an action performed by the JavaScript interpreter that moves function and variable declarations to the top of their containing scope.
 
 ### I

--- a/glossary/BRUNCH.md
+++ b/glossary/BRUNCH.md
@@ -1,5 +1,5 @@
 # Brunch
 
-[Brunch](http://brunch.io/) is a builder. Not a generic task runner, but a specialized tool focusing on the production of a small number of deployment-ready files from a large number of heterogenous development files or trees.
+[Brunch](http://brunch.io/) est un constructeur. Ce n'est pas un programme exécutant des tâches génériques, mais un outil spécialisé axé sur la production d'un petit nombre de fichiers prêts à être déployés à partir d'un plus grand nombre de fichiers ou arborescences de développement hétérogènes.
 
-Brunch is fundamentally specialized and geared towards building assets, these files that get used in the end by the runtime platform, usually a web browser. It thus comes pre-equipped with a number of behaviors and features such as concatenation, minification and watching of source files.
+Brunch est fondamentalement spécialisé et équipé pour construire des assets, ces fichiers qui seront à la fin utilisés par la plateforme d'exécution, habituellement un navigateur web. Il est pré-équipé d'un certain nombre de comportements et de fonctionnalités telles que la concaténation, la minimisation et l'observation de fichiers source.

--- a/glossary/HAPI.md
+++ b/glossary/HAPI.md
@@ -1,3 +1,3 @@
 # Hapi
 
-[Hapi](http://hapijs.com/) is a simple to use configuration-centric framework with built-in support for input validation, caching, authentication, and other essential facilities for building web and services applications. Hapi enables developers to focus on writing reusable application logic in a highly modular and prescriptive approach.
+[Hapi](http://hapijs.com/) est un framework simple d'utilisation axé sur la configuration avec un support intégré pour la validation de la saisie, la mise en cache, l'authentification et d'autres facilités essentielles pour construire des applications web et des services. Hapi permet aux développeurs de se concentrer sur l'écriture de logique d'application réutilisable dans une approche hautement modulable et prescriptible.


### PR DESCRIPTION
Passage de l'anglais au français pour les paragraphes concernant Brunch et Hapi dans le README et pour les fichiers correspondants dans le dossier glossary
